### PR TITLE
Added scripts to use citekeys instead of titles for item lookup.

### DIFF
--- a/Papers 3 Export Collections via citekey.scpt
+++ b/Papers 3 Export Collections via citekey.scpt
@@ -1,0 +1,58 @@
+set cout to {}
+tell application "Papers 3 (Legacy)"
+	repeat with coll in every collection item
+		set cout to cout & my get_pubs(coll)
+	end repeat
+end tell
+
+
+on get_pubs(coll)
+	tell application "Papers 3 (Legacy)"
+		set thisColl to {collectionName:coll's name as string}
+		
+		set childCollections to {}
+		
+		--		set out to {"Collection: " & coll's name as string}
+		log coll's name as string
+		repeat with subcoll in coll's every collection item
+			set childCollections to childCollections & my get_pubs(subcoll)
+		end repeat
+		set thisColl to thisColl & {children:childCollections}
+		
+		set memberPublications to {}
+		
+		repeat with p in the every publication item of coll
+			set tmpCiteKey to the citekey of p
+			set tmpTitle to the title of p
+			set memberPublications to memberPublications & {{tmpCiteKey, tmpTitle}} 
+		end repeat
+		set thisColl to thisColl & {entries:memberPublications}
+	end tell
+	return {thisColl}
+end get_pubs
+
+
+-- Source: https://stackoverflow.com/a/3781066/49663
+on write_to_file(this_data, target_file, append_data) -- (string, file path as string, boolean)
+	try
+		set the target_file to the target_file as text
+		set the open_target_file to ¬
+			open for access file target_file with write permission
+		if append_data is false then ¬
+			set eof of the open_target_file to 0
+		write this_data to the open_target_file starting at eof as «class utf8»
+		close access the open_target_file
+		return true
+	on error
+		try
+			close access file target_file
+		end try
+		return false
+	end try
+end write_to_file
+
+my write_to_file("var data = ", ((path to desktop folder) as text) & "papers_collections.citekey.json", false)
+tell application "JSON Helper"
+	set j_out to (make JSON from cout)
+	my write_to_file(j_out, ((path to desktop folder) as text) & "papers_collections.citekey.json", true)
+end tell

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ doable.
 	 file. That will help you get all of your papers from Papers 3 into
 	 Zotero.
 2. Make sure Papers 3 is running and you've installed the JSON Helper
-	 above. Open `Papers 3 Export Collections.scpt` and run it. This
+	 above. Open `Papers 3 Export Collections via citekey.scpt` and run it. This
 	 will create a file on your desktop called
 	 `papers_collections.json`.
 3. In Zotero, open both **Tools→Developer→Error Console** and
@@ -46,6 +46,6 @@ doable.
 	 see if anything goes horribly wrong.
 4. Copy and paste the contents of `Desktop/papers_collections.json` into the
 	 left pane of the Run JavaScript window.
-5. Copy and paste the contents of `import_papers3.js` below that.
+5. Copy and paste the contents of `import_papers3.citekey.js` below that.
 6. Make sure **Run as async function** is checked.
 7. Hit **Run** and sit back and watch.

--- a/import_papers3.citekey.js
+++ b/import_papers3.citekey.js
@@ -1,0 +1,51 @@
+var find_paper_by_citekey = async function(paper_citekey) {
+  var s = new Zotero.Search();
+  s.libraryID = Zotero.Libraries.userLibraryID;
+  s.addCondition('citationKey', 'is', paper_citekey);
+  return await s.search();
+}
+
+var add_item = async function(coll_obj) {
+  
+  // Set up a new Collection with this name
+  var collname = coll_obj['collectionName'];
+  var coll = new Zotero.Collection();
+  coll.name = collname
+  await coll.saveTx();
+  
+  // handle any children this collection might have
+  if (coll_obj['children'].length > 0) {
+    for (const child_coll of coll_obj['children']) {
+      var sub_coll = await add_item(child_coll)
+      sub_coll.parentID = coll.id;
+      await sub_coll.saveTx();
+    }
+  }
+  
+  // now manage the actual entries themselves
+  for (const this_entry of coll_obj['entries']) {
+    // destructure the list
+    var this_cite_key = this_entry[0];
+    var this_title = this_entry[1]; // we don't actually need this, it just makes debugging easier
+    
+    paper_ids = await find_paper_by_citekey(this_cite_key)
+  	for(pid of paper_ids)
+  	{
+  		await Zotero.DB.executeTransaction(async function()
+  		{
+  			await coll.addItem(pid);
+  			await coll.save();
+  		});
+  	}
+  }
+  
+  return coll;
+  
+}
+
+for(const coll_list of data)
+{
+	await add_item(coll_list);
+}
+
+return "Finished!";


### PR DESCRIPTION
Hello! Thank you so much for this tool, it really was a lifesaver I encountered a few issues while using it, and in the course of fixing them, thought that I might offer them back in case they are of interest. The original version of the script uses titles for item lookup, which has issues if there are multiple entries in the bibliography that share a title. This can happen for a few reasons, including:

1. Duplicate entries in Papers
2. Papers that happen to have the same title, which does happen, especially in the case of...
3. Papers that are first published at a conference, and then later are expanded into a full journal publication, or included in a special issue of a journal that publishes selected papers from a conference.

Fortunately, the export/import method prescribed in `Papers3_to_Zotero.py` will result in Zotero preserving the original citekeys from the Papers-generated .bib file, and it turns out that Papers 3's AppleScript support allows us to access those citekeys, as well. Using these allows for a much more reliable duplication of the Papers 3 collection structure and membership.

I left the original title-oriented scripts in the repository as they may certainly still be of use.